### PR TITLE
Add precip_rate diagnostics to blk2m

### DIFF
--- a/src/solvers/blk_2m/slvr_blk_2m_common.hpp
+++ b/src/solvers/blk_2m/slvr_blk_2m_common.hpp
@@ -16,12 +16,13 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
   public:
   using ix = typename ct_params_t::ix; // TODO: it's now in solver_common - is it needed here?
   using real_t = typename ct_params_t::real_t;
+  
   private:
-
   // a 2D/3D array with copy of the environmental total pressure of dry air
   typename parent_t::arr_t &p_e;
 
   protected:
+  typename parent_t::arr_t &precipitation_rate;
 
   // accumulated water falling out of domain
   real_t liquid_puddle;
@@ -39,8 +40,8 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
   {
     parent_t::diag();
     
-    // TODO: recording precipitation flux
-    // this->record_aux_dsc("precip_rate",precipitation_rate);    
+    // recording precipitation flux
+    this->record_aux_dsc("precip_rate", precipitation_rate);    
 
     /*
     assert(this->rank == 0);
@@ -151,7 +152,7 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
   static void alloc(typename parent_t::mem_t *mem, const int &n_iters)
   {
     parent_t::alloc(mem, n_iters);
-    parent_t::alloc_tmp_sclr(mem, __FILE__, 1); // p_e
+    parent_t::alloc_tmp_sclr(mem, __FILE__, 2); // p_e, precipitation_rate
   }
 
   // ctor
@@ -162,6 +163,7 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
     parent_t(args, p),
     params(p),
     liquid_puddle(0),
-    p_e(args.mem->tmp[__FILE__][0][0])
+    p_e(args.mem->tmp[__FILE__][0][0]),
+    precipitation_rate(args.mem->tmp[__FILE__][0][1])
   {}
 };

--- a/src/solvers/blk_2m/slvr_blk_2m_common.hpp
+++ b/src/solvers/blk_2m/slvr_blk_2m_common.hpp
@@ -22,7 +22,9 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
   typename parent_t::arr_t &p_e;
 
   protected:
-  typename parent_t::arr_t &precipitation_rate;
+  typename parent_t::arr_t &rr_flux;
+  typename parent_t::arr_t &nr_flux;
+
 
   // accumulated water falling out of domain
   real_t liquid_puddle;
@@ -41,7 +43,8 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
     parent_t::diag();
     
     // recording precipitation flux
-    this->record_aux_dsc("precip_rate", precipitation_rate);    
+    this->record_aux_dsc("precip_rate_rr", rr_flux);    
+    this->record_aux_dsc("precip_rate_nr", nr_flux);    
 
     /*
     assert(this->rank == 0);
@@ -152,7 +155,7 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
   static void alloc(typename parent_t::mem_t *mem, const int &n_iters)
   {
     parent_t::alloc(mem, n_iters);
-    parent_t::alloc_tmp_sclr(mem, __FILE__, 2); // p_e, precipitation_rate
+    parent_t::alloc_tmp_sclr(mem, __FILE__, 3); // p_e, rr_flux, nr_flux
   }
 
   // ctor
@@ -164,6 +167,7 @@ class slvr_blk_2m_common : public std::conditional_t<ct_params_t::sgs_scheme == 
     params(p),
     liquid_puddle(0),
     p_e(args.mem->tmp[__FILE__][0][0]),
-    precipitation_rate(args.mem->tmp[__FILE__][0][1])
+    rr_flux(args.mem->tmp[__FILE__][0][1]),
+    nr_flux(args.mem->tmp[__FILE__][0][2])
   {}
 };

--- a/src/solvers/blk_2m/update_rhs_blk_2m_common.hpp
+++ b/src/solvers/blk_2m/update_rhs_blk_2m_common.hpp
@@ -16,8 +16,11 @@ void slvr_blk_2m_common<ct_params_t>::update_rhs(
   parent_t::update_rhs(rhs, dt, at); // shouldnt forcings be after condensation to be consistent with lgrngn solver?
 
   // zero-out precipitation rate, will be set in columnwise
-  if(at == 0)
-    precipitation_rate(this->ijk) = 0;
+  if(at == 0) 
+  {
+    rr_flux(this->ijk) = 0;
+    nr_flux(this->ijk) = 0;
+  }
 
   this->mem->barrier();
 

--- a/src/solvers/blk_2m/update_rhs_blk_2m_common.hpp
+++ b/src/solvers/blk_2m/update_rhs_blk_2m_common.hpp
@@ -15,6 +15,10 @@ void slvr_blk_2m_common<ct_params_t>::update_rhs(
 
   parent_t::update_rhs(rhs, dt, at); // shouldnt forcings be after condensation to be consistent with lgrngn solver?
 
+  // zero-out precipitation rate, will be set in columnwise
+  if(at == 0)
+    precipitation_rate(this->ijk) = 0;
+
   this->mem->barrier();
 
   // cell-wise

--- a/src/solvers/slvr_blk_1m.hpp
+++ b/src/solvers/slvr_blk_1m.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "blk_1m/slvr_blk_1m_common.hpp"
-
 #include <libcloudph++/blk_1m/rhs_columnwise.hpp>
 
 template <class ct_params_t, class enableif = void>

--- a/src/solvers/slvr_blk_2m.hpp
+++ b/src/solvers/slvr_blk_2m.hpp
@@ -46,14 +46,16 @@ class slvr_blk_2m<
         auto
           dot_rr = rhs.at(parent_t::ix::rr)(i, this->j),
           dot_nr = rhs.at(parent_t::ix::nr)(i, this->j);
+          precipitation_rate_arg = this->precipitation_rate(i, this->j);
         const auto
           rhod   = (*this->mem->G)(i, this->j),
           rr     = this->state(parent_t::ix::rr)(i, this->j),
           nr     = this->state(parent_t::ix::nr)(i, this->j);
         this->liquid_puddle += -libcloudphxx::blk_2m::rhs_columnwise<real_t>(
-          this->params.cloudph_opts, dot_rr, dot_nr, rhod, rr, nr, this->dt, this->params.dz
+          this->params.cloudph_opts, dot_rr, dot_nr, precipitation_rate_arg, rhod, rr, nr, this->dt, this->params.dz
         );
       }
+      rhs.at(parent_t::ix::rr)(this->ijk) += this->precipitation_rate(this->ijk);
 
       this->mem->barrier();
       if(this->rank == 0)
@@ -102,14 +104,16 @@ class slvr_blk_2m<
           auto
           dot_rr = rhs.at(parent_t::ix::rr)(i, j, this->k),
           dot_nr = rhs.at(parent_t::ix::nr)(i, j, this->k);
+          precipitation_rate_arg = this->precipitation_rate(i, j, this->k);
           const auto
           rhod   = (*this->mem->G)(i, j, this->k),
           rr     = this->state(parent_t::ix::rr)(i, j, this->k),
           nr     = this->state(parent_t::ix::nr)(i, j, this->k);
           this->liquid_puddle += -libcloudphxx::blk_2m::rhs_columnwise<real_t>(
-            this->params.cloudph_opts, dot_rr, dot_nr, rhod, rr, nr, this->dt, this->params.dz
+            this->params.cloudph_opts, dot_rr, dot_nr, precipitation_rate_arg, rhod, rr, nr, this->dt, this->params.dz
           );
         }
+        rhs.at(parent_t::ix::rr)(this->ijk) += this->precipitation_rate(this->ijk);
 
       this->mem->barrier();
       if(this->rank == 0)

--- a/src/solvers/slvr_blk_2m.hpp
+++ b/src/solvers/slvr_blk_2m.hpp
@@ -2,7 +2,6 @@
 #include "blk_2m/slvr_blk_2m_common.hpp"
 #include <libcloudph++/blk_2m/rhs_columnwise.hpp>
 
-
 template <class ct_params_t, class enableif = void>
 class slvr_blk_2m
 {};
@@ -44,18 +43,20 @@ class slvr_blk_2m<
       for (int i = this->i.first(); i <= this->i.last(); ++i)
       {
         auto
-          dot_rr = rhs.at(parent_t::ix::rr)(i, this->j),
-          dot_nr = rhs.at(parent_t::ix::nr)(i, this->j);
-          precipitation_rate_arg = this->precipitation_rate(i, this->j);
+          // dot_rr = rhs.at(parent_t::ix::rr)(i, this->j),
+          // dot_nr = rhs.at(parent_t::ix::nr)(i, this->j);
+          rr_flux_arg = this->rr_flux(i, this->j),
+          nr_flux_arg = this->nr_flux(i, this->j);
         const auto
           rhod   = (*this->mem->G)(i, this->j),
           rr     = this->state(parent_t::ix::rr)(i, this->j),
           nr     = this->state(parent_t::ix::nr)(i, this->j);
         this->liquid_puddle += -libcloudphxx::blk_2m::rhs_columnwise<real_t>(
-          this->params.cloudph_opts, dot_rr, dot_nr, precipitation_rate_arg, rhod, rr, nr, this->dt, this->params.dz
+          this->params.cloudph_opts, rr_flux_arg, nr_flux_arg, rhod, rr, nr, this->dt, this->params.dz
         );
       }
-      rhs.at(parent_t::ix::rr)(this->ijk) += this->precipitation_rate(this->ijk);
+      rhs.at(parent_t::ix::rr)(this->ijk) += this->rr_flux(this->ijk);
+      rhs.at(parent_t::ix::rr)(this->ijk) += this->nr_flux(this->ijk);
 
       this->mem->barrier();
       if(this->rank == 0)
@@ -102,18 +103,20 @@ class slvr_blk_2m<
         for (int j = this->j.first(); j <= this->j.last(); ++j)
         {
           auto
-          dot_rr = rhs.at(parent_t::ix::rr)(i, j, this->k),
-          dot_nr = rhs.at(parent_t::ix::nr)(i, j, this->k);
-          precipitation_rate_arg = this->precipitation_rate(i, j, this->k);
+          // dot_rr = rhs.at(parent_t::ix::rr)(i, j, this->k),
+          // dot_nr = rhs.at(parent_t::ix::nr)(i, j, this->k);
+          rr_flux_arg = this->rr_flux(i, this->j),
+          nr_flux_arg = this->nr_flux(i, this->j);    
           const auto
           rhod   = (*this->mem->G)(i, j, this->k),
           rr     = this->state(parent_t::ix::rr)(i, j, this->k),
           nr     = this->state(parent_t::ix::nr)(i, j, this->k);
           this->liquid_puddle += -libcloudphxx::blk_2m::rhs_columnwise<real_t>(
-            this->params.cloudph_opts, dot_rr, dot_nr, precipitation_rate_arg, rhod, rr, nr, this->dt, this->params.dz
+            this->params.cloudph_opts, rr_flux_arg, nr_flux_arg, rhod, rr, nr, this->dt, this->params.dz
           );
         }
-        rhs.at(parent_t::ix::rr)(this->ijk) += this->precipitation_rate(this->ijk);
+        rhs.at(parent_t::ix::rr)(this->ijk) += this->rr_flux(this->ijk);
+        rhs.at(parent_t::ix::rr)(this->ijk) += this->nr_flux(this->ijk);
 
       this->mem->barrier();
       if(this->rank == 0)

--- a/src/solvers/slvr_blk_2m.hpp
+++ b/src/solvers/slvr_blk_2m.hpp
@@ -43,20 +43,18 @@ class slvr_blk_2m<
       for (int i = this->i.first(); i <= this->i.last(); ++i)
       {
         auto
-          // dot_rr = rhs.at(parent_t::ix::rr)(i, this->j),
-          // dot_nr = rhs.at(parent_t::ix::nr)(i, this->j);
-          rr_flux_arg = this->rr_flux(i, this->j),
-          nr_flux_arg = this->nr_flux(i, this->j);
+          dot_rr = this->rr_flux(i, this->j),
+          dot_nr = this->nr_flux(i, this->j);
         const auto
           rhod   = (*this->mem->G)(i, this->j),
           rr     = this->state(parent_t::ix::rr)(i, this->j),
           nr     = this->state(parent_t::ix::nr)(i, this->j);
         this->liquid_puddle += -libcloudphxx::blk_2m::rhs_columnwise<real_t>(
-          this->params.cloudph_opts, rr_flux_arg, nr_flux_arg, rhod, rr, nr, this->dt, this->params.dz
+          this->params.cloudph_opts, dot_rr, dot_nr, rhod, rr, nr, this->dt, this->params.dz
         );
       }
       rhs.at(parent_t::ix::rr)(this->ijk) += this->rr_flux(this->ijk);
-      rhs.at(parent_t::ix::rr)(this->ijk) += this->nr_flux(this->ijk);
+      rhs.at(parent_t::ix::nr)(this->ijk) += this->nr_flux(this->ijk);
 
       this->mem->barrier();
       if(this->rank == 0)
@@ -103,20 +101,18 @@ class slvr_blk_2m<
         for (int j = this->j.first(); j <= this->j.last(); ++j)
         {
           auto
-          // dot_rr = rhs.at(parent_t::ix::rr)(i, j, this->k),
-          // dot_nr = rhs.at(parent_t::ix::nr)(i, j, this->k);
-          rr_flux_arg = this->rr_flux(i, this->j),
-          nr_flux_arg = this->nr_flux(i, this->j);    
+          dot_rr = this->rr_flux(i, this->j),
+          dot_nr = this->nr_flux(i, this->j);    
           const auto
           rhod   = (*this->mem->G)(i, j, this->k),
           rr     = this->state(parent_t::ix::rr)(i, j, this->k),
           nr     = this->state(parent_t::ix::nr)(i, j, this->k);
           this->liquid_puddle += -libcloudphxx::blk_2m::rhs_columnwise<real_t>(
-            this->params.cloudph_opts, rr_flux_arg, nr_flux_arg, rhod, rr, nr, this->dt, this->params.dz
+            this->params.cloudph_opts, dot_rr, dot_nr, rhod, rr, nr, this->dt, this->params.dz
           );
         }
         rhs.at(parent_t::ix::rr)(this->ijk) += this->rr_flux(this->ijk);
-        rhs.at(parent_t::ix::rr)(this->ijk) += this->nr_flux(this->ijk);
+        rhs.at(parent_t::ix::nr)(this->ijk) += this->nr_flux(this->ijk);
 
       this->mem->barrier();
       if(this->rank == 0)


### PR DESCRIPTION
This is running, but I don't think it's correct yet. There are negative values in the `precip_rate_rr` and `precip_rate_nr` fields.
![image](https://github.com/igfuw/UWLCM/assets/6875824/5eb1bf89-12fa-4eff-a693-05a236db88c9)

@pdziekan Do you see anything obviously wrong with the implementation here? I'm not sure, but I think that what gets returned from `rhs_columnwise` should be only the terminal velocity advection (not including `w` or other microphysical sources/sinks of rain), is that correct?
