### PR TITLE
weaker Smagorinsky

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,10 @@ set_target_properties(uwlcm PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_features(uwlcm PRIVATE cxx_std_14)
 
 # search for Boost
-find_package(Boost COMPONENTS thread iostreams system timer program_options filesystem REQUIRED)
-if(TARGET Boost::thread AND TARGET Boost::iostreams AND TARGET Boost::system AND TARGET Boost::timer AND TARGET Boost::program_options AND TARGET Boost::filesystem AND TARGET Boost::atomic AND TARGET Boost::regex) # atomic and regex are required by some other libs and boost was trying to link them via target although the target didnt exist
+find_package(Boost COMPONENTS thread iostreams system timer program_options filesystem asio REQUIRED)
+if(TARGET Boost::thread AND TARGET Boost::iostreams AND TARGET Boost::system AND TARGET Boost::timer AND TARGET Boost::program_options AND TARGET Boost::asio AND TARGET Boost::filesystem AND TARGET Boost::atomic AND TARGET Boost::regex) # atomic and regex are required by some other libs and boost was trying to link them via target although the target didnt exist
   message("linkiing boost targets")
-  target_link_libraries(uwlcm PRIVATE Boost::thread Boost::iostreams Boost::system Boost::timer Boost::program_options Boost::filesystem Boost::atomic Boost::regex)
+  target_link_libraries(uwlcm PRIVATE Boost::thread Boost::iostreams Boost::system Boost::timer Boost::program_options Boost::asio Boost::filesystem Boost::atomic Boost::regex)
 else()
   message("linkiing boost without targets")
   # we dont link using targets, because they are not set if there is some discrepancy between cmake and boost version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,10 @@ set_target_properties(uwlcm PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_features(uwlcm PRIVATE cxx_std_14)
 
 # search for Boost
-find_package(Boost COMPONENTS thread iostreams system timer program_options filesystem asio REQUIRED)
-if(TARGET Boost::thread AND TARGET Boost::iostreams AND TARGET Boost::system AND TARGET Boost::timer AND TARGET Boost::program_options AND TARGET Boost::asio AND TARGET Boost::filesystem AND TARGET Boost::atomic AND TARGET Boost::regex) # atomic and regex are required by some other libs and boost was trying to link them via target although the target didnt exist
+find_package(Boost COMPONENTS thread iostreams system timer program_options filesystem REQUIRED)
+if(TARGET Boost::thread AND TARGET Boost::iostreams AND TARGET Boost::system AND TARGET Boost::timer AND TARGET Boost::program_options AND TARGET Boost::filesystem AND TARGET Boost::atomic AND TARGET Boost::regex) # atomic and regex are required by some other libs and boost was trying to link them via target although the target didnt exist
   message("linkiing boost targets")
-  target_link_libraries(uwlcm PRIVATE Boost::thread Boost::iostreams Boost::system Boost::timer Boost::program_options Boost::asio Boost::filesystem Boost::atomic Boost::regex)
+  target_link_libraries(uwlcm PRIVATE Boost::thread Boost::iostreams Boost::system Boost::timer Boost::program_options Boost::filesystem Boost::atomic Boost::regex)
 else()
   message("linkiing boost without targets")
   # we dont link using targets, because they are not set if there is some discrepancy between cmake and boost version

--- a/src/solvers/slvr_common.hpp
+++ b/src/solvers/slvr_common.hpp
@@ -7,6 +7,7 @@
 #include <libcloudph++/common/output.hpp>
 #include "../detail/get_uwlcm_git_revision.hpp"
 #include "../detail/ForceParameters.hpp"
+#include <boost/asio/ip/host_name.hpp>
 
 struct smg_tag  {};
 struct iles_tag {};
@@ -106,6 +107,7 @@ class slvr_common : public slvr_dim<ct_params_t>
       std::string run_command;
       for(int i=0; i<ac; ++i)
         run_command += std::string(av[i]) + std::string(" ");
+      this->record_aux_const("hostname", "misc", boost::asio::ip::host_name());  
       this->record_aux_const("run command", "misc", run_command);  
       this->record_aux_const("omp_max_threads (on MPI rank 0)", omp_get_max_threads());  
       this->record_aux_const("MPI compiler (true/false)", "MPI details", 


### PR DESCRIPTION
In eddy viscosity, use tdef_sq instead of sqrt(tdef_sq).
Default Smagorinsky in mpdata does the same, but isn't sqrt(tdef_sq) in agreement with the formulas? Double-check the formulas and the computation...

This makes eddy viscosity smaller,  hence Deardorffs char length (dx*dy*dz)^(1/3) can be used instead of dz (e.g. in Dycoms).